### PR TITLE
feat: configured experiment end button, and publish button properly

### DIFF
--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/CodeController.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/CodeController.java
@@ -1,27 +1,19 @@
 package com.cmput301w21t06.crowdfly.Controllers;
 
-import android.content.Intent;
 import android.graphics.Bitmap;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
 import com.cmput301w21t06.crowdfly.Models.Barcode;
-import com.cmput301w21t06.crowdfly.Models.QRCode;
 import com.cmput301w21t06.crowdfly.Models.Trial;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firestore.v1.GetDocumentRequest;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * This abstract controller contains the framework for operations related to Barcode and QRCodes

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
@@ -68,7 +68,7 @@ public class ExperimentAdapter extends ArrayAdapter<Experiment> {
         published.setText(experiment.getIsPublished() ? "Unpublished" : Html.fromHtml("<b><font color='blue'>" +"Published"+"</b></font>" ));
         constantIsPublished = experiment.getIsPublished();
         Log.e("is published", String.valueOf(constantIsPublished));
-        status.setText(experiment.getStillRunning() ? "Active" : Html.fromHtml("<b><font color='blue'>" +"Inactive"+"</b></font>" ));
+        status.setText(experiment.getStillRunning() ? "Active" : Html.fromHtml("<b><font color='red'>" +"Inactive"+"</b></font>" ));
         constantStillRunning = experiment.getStillRunning();
         Log.e("still Running", String.valueOf(constantStillRunning));
 

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
@@ -65,7 +65,7 @@ public class ExperimentAdapter extends ArrayAdapter<Experiment> {
         // set content description
         description.setText(experiment.getDescription());
         ownerName.setText(UserController.reverseConvert(experiment.getOwnerID()));
-        published.setText(experiment.getIsPublished() ? "Unpublished" : Html.fromHtml("<b><font color='blue'>" +"Published"+"</b></font>" ));
+        published.setText(experiment.getIsPublished() ? Html.fromHtml("<b><font color='blue'>" +"Published"+"</b></font>" ) : "Unpublished");
         constantIsPublished = experiment.getIsPublished();
         Log.e("is published", String.valueOf(constantIsPublished));
         status.setText(experiment.getStillRunning() ? "Active" : Html.fromHtml("<b><font color='red'>" +"Inactive"+"</b></font>" ));

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Controllers/ExperimentAdapter.java
@@ -2,21 +2,17 @@ package com.cmput301w21t06.crowdfly.Controllers;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.Color;
-import android.speech.tts.TextToSpeech;
 import android.text.Html;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.Button;
 import android.widget.TextView;
 
 import com.cmput301w21t06.crowdfly.Database.UserController;
 import com.cmput301w21t06.crowdfly.Models.Experiment;
 import com.cmput301w21t06.crowdfly.R;
-import com.cmput301w21t06.crowdfly.Views.ViewLocationActivity;
 
 import java.util.ArrayList;
 
@@ -27,8 +23,8 @@ public class ExperimentAdapter extends ArrayAdapter<Experiment> {
 
     private ArrayList<Experiment> experiments;
     private Context context;
+    private boolean constantIsPublished;
     private boolean constantStillRunning;
-
     /**
      * this is the constructor of the experiment adapter
      * @param context
@@ -61,16 +57,20 @@ public class ExperimentAdapter extends ArrayAdapter<Experiment> {
         // get all content from the page
         TextView description = view.findViewById(R.id.exp_description);
         TextView ownerName = view.findViewById(R.id.exp_ownerName);
-        TextView status = view.findViewById(R.id.exp_status);
+        TextView published = view.findViewById(R.id.exp_published);
         TextView numTrials = view.findViewById(R.id.exp_numTrials);
         TextView region = view.findViewById(R.id.exp_region);
+        TextView status = view.findViewById(R.id.exp_status);
 
         // set content description
         description.setText(experiment.getDescription());
         ownerName.setText(UserController.reverseConvert(experiment.getOwnerID()));
-        status.setText(experiment.getStillRunning() ? "Unpublished" : Html.fromHtml("<b><font color='blue'>" +"Published"+"</b></font>" ));
+        published.setText(experiment.getIsPublished() ? "Unpublished" : Html.fromHtml("<b><font color='blue'>" +"Published"+"</b></font>" ));
+        constantIsPublished = experiment.getIsPublished();
+        Log.e("is published", String.valueOf(constantIsPublished));
+        status.setText(experiment.getStillRunning() ? "Active" : Html.fromHtml("<b><font color='blue'>" +"Inactive"+"</b></font>" ));
         constantStillRunning = experiment.getStillRunning();
-        Log.e("still running", String.valueOf(constantStillRunning));
+        Log.e("still Running", String.valueOf(constantStillRunning));
 
         numTrials.setText(String.valueOf(experiment.getMinTrials()));
         RegionViewSetter.setRegion(region,experiment.getRegion());

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Models/Experiment.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Models/Experiment.java
@@ -1,16 +1,11 @@
 package com.cmput301w21t06.crowdfly.Models;
 
-import android.util.Log;
-
-import com.cmput301w21t06.crowdfly.Controllers.ExperimentLog;
 import com.cmput301w21t06.crowdfly.Database.CrowdFlyListeners;
 import com.cmput301w21t06.crowdfly.Database.QuestionController;
 import com.cmput301w21t06.crowdfly.Database.SubscriptionController;
 import com.cmput301w21t06.crowdfly.Database.TrialController;
 import com.cmput301w21t06.crowdfly.Database.UserController;
-import com.google.firebase.firestore.local.QueryEngine;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,11 +16,13 @@ import java.util.Map;
  */
 
 public class Experiment {
+
     // Eventually this class will import and export JSON objects to firebase, so these attributes
     //methods are subject to change
     private String description;
     private String region;
     private int minTrials;
+    private Boolean isPublished;
     private Boolean stillRunning;
     private ArrayList<User> subscribedUsers;
     private ArrayList<Question> questions;
@@ -53,6 +50,7 @@ public class Experiment {
         this.region = reg;
         this.minTrials = minT;
         this.stillRunning = true;
+        this.isPublished = false;
         this.ownerID = userID;
         this.type = type;
         this.regionEnabled = regionEnabled;
@@ -70,6 +68,7 @@ public class Experiment {
         this.region = (String) data.get("region");
         this.minTrials = ((Long) data.get("minTrials")).intValue();
         this.stillRunning = (boolean) data.get("stillRunning");
+        this.isPublished = (boolean) data.get("isPublished");
         this.ownerID = (String) data.get("ownerID");
         this.experimentId = (String) data.get("experimentID");
         this.type = (String) data.get("type");
@@ -239,6 +238,14 @@ public class Experiment {
     public Boolean getStillRunning() { return stillRunning;}
 
     /**
+     * This check if the experiment is published
+     * @return
+     * THis is a boolean indicating whether or not the experiment is still active
+     */
+
+    public Boolean getIsPublished() { return isPublished;}
+
+    /**
      * This returns the experiment ID
      * @return
      * This is the experiment ID
@@ -262,6 +269,15 @@ public class Experiment {
      */
 
     public void setStillRunning(Boolean stillRunning) { this.stillRunning = stillRunning; }
+
+    /**
+     * This can be used to change the experiment between the active and inactive state
+     * @param isPublished
+     * This is a boolean indicating if it is still active
+     */
+
+    public void setIsPublished(Boolean isPublished) { this.isPublished = isPublished; }
+
 
     /**
      * This is used to set the owner ID of a new experiment
@@ -336,6 +352,7 @@ public class Experiment {
         exp.put("region", this.region);
         exp.put("minTrials", (long) this.minTrials);
         exp.put("stillRunning", this.stillRunning);
+        exp.put("isPublished", this.isPublished);
         exp.put("ownerID", this.ownerID);
         exp.put("experimentID", this.experimentId);
         exp.put("displayID", UserController.reverseConvert(ownerID));

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Models/User.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Models/User.java
@@ -8,8 +8,6 @@
 
 package com.cmput301w21t06.crowdfly.Models;
 
-import androidx.annotation.NonNull;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Views/ViewTrialLogActivity.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Views/ViewTrialLogActivity.java
@@ -71,6 +71,7 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
     private Button qrButton;
     private Button subButton;
     private Button endButton;
+    private Button pubButton;
     private Button statButton;
     private Spinner dropdown;
     private DropdownAdapter dropAdapter;
@@ -97,6 +98,7 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
         setContentView(R.layout.activity_view_trial_log);
         mapButton = findViewById(R.id.mapButton);
         endButton = findViewById(R.id.endButton);
+        pubButton = findViewById(R.id.pubButton);
         dropdown = findViewById(R.id.dropDown);
         statButton = findViewById(R.id.statisticButton);
         //only update the trialtype once per experiment
@@ -212,11 +214,11 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
                     if(isOwner){
                         if(!currentExperiment.getStillRunning()){
                             currentExperiment.setStillRunning(true);
-                            endButton.setText("Publish");
+                            endButton.setText("End");
                         }
                         else {
                             currentExperiment.setStillRunning(false);
-                            endButton.setText("Unpublish");
+                            endButton.setText("Reopen");
                         }
 
                         ExperimentController.setExperimentData(currentExperiment);
@@ -224,6 +226,29 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
                     else {
                         Log.e("rr","run");
                         Toaster.makeCrispyToast(ViewTrialLogActivity.this, "Only the owner can end an experiment!");
+                    }
+                }
+            }
+        });
+        pubButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(currentExperiment!=null && currentUser != null){
+                    if(isOwner){
+                        if(!currentExperiment.getIsPublished()){
+                            currentExperiment.setIsPublished(true);
+                            pubButton.setText("Published");
+                        }
+                        else {
+                            currentExperiment.setIsPublished(false);
+                            pubButton.setText("Unpublished");
+                        }
+
+                        ExperimentController.setExperimentData(currentExperiment);
+                    }
+                    else {
+                        Log.e("rr","run");
+                        Toaster.makeCrispyToast(ViewTrialLogActivity.this, "Only the owner can publish an experiment!");
                     }
                 }
             }
@@ -472,10 +497,17 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
         this.isOwner = this.currentExperiment.getOwnerID().equals(FirebaseAuth.getInstance().getUid());
         if(currentExperiment.getStillRunning()){
 
-            endButton.setText("Publish");
+            endButton.setText("End");
         }
         else{
-            endButton.setText("Unpublish");
+            endButton.setText("Reopen");
+        }
+        if (currentExperiment.getIsPublished()) {
+
+            pubButton.setText("Publish");
+        }
+        else{
+            pubButton.setText("Unpublish");
         }
     }
 

--- a/code/app/src/main/java/com/cmput301w21t06/crowdfly/Views/ViewTrialLogActivity.java
+++ b/code/app/src/main/java/com/cmput301w21t06/crowdfly/Views/ViewTrialLogActivity.java
@@ -237,11 +237,11 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
                     if(isOwner){
                         if(!currentExperiment.getIsPublished()){
                             currentExperiment.setIsPublished(true);
-                            pubButton.setText("Published");
+                            pubButton.setText("Unpublish");
                         }
                         else {
                             currentExperiment.setIsPublished(false);
-                            pubButton.setText("Unpublished");
+                            pubButton.setText("Publish");
                         }
 
                         ExperimentController.setExperimentData(currentExperiment);
@@ -504,10 +504,10 @@ public class ViewTrialLogActivity extends AppCompatActivity implements
         }
         if (currentExperiment.getIsPublished()) {
 
-            pubButton.setText("Publish");
+            pubButton.setText("Unpublish");
         }
         else{
-            pubButton.setText("Unpublish");
+            pubButton.setText("Publish");
         }
     }
 

--- a/code/app/src/main/res/layout/activity_view_trial_log.xml
+++ b/code/app/src/main/res/layout/activity_view_trial_log.xml
@@ -118,15 +118,27 @@
 
         <Button
             android:id="@+id/endButton"
-            android:textSize="13dp"
-            android:layout_width="228dp"
+            android:layout_width="175dp"
             android:layout_height="46dp"
-            android:layout_marginBottom="128dp"
+            android:layout_marginBottom="132dp"
             android:backgroundTint="@color/bluejay"
-            android:text="Pub Experiment"
+            android:text="END "
+            android:textSize="13dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.497"
+            app:layout_constraintHorizontal_bias="0.545"
+            app:layout_constraintStart_toEndOf="@+id/pubButton" />
+
+        <Button
+            android:id="@+id/pubButton"
+            android:layout_width="175dp"
+            android:layout_height="46dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="132dp"
+            android:backgroundTint="@color/bluejay"
+            android:text="PUB BUTTON"
+            android:textSize="13dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
         <Button

--- a/code/app/src/main/res/layout/experiment_content.xml
+++ b/code/app/src/main/res/layout/experiment_content.xml
@@ -49,6 +49,16 @@
             app:layout_constraintTop_toBottomOf="@+id/exp_numTrials_title" />
 
         <TextView
+            android:id="@+id/exp_status_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="36dp"
+            android:text="@string/status"
+            android:textColor="#131313"
+            app:layout_constraintEnd_toStartOf="@+id/exp_status"
+            app:layout_constraintTop_toBottomOf="@+id/exp_numTrials_title" />
+
+        <TextView
             android:id="@+id/exp_ownerName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -59,24 +69,34 @@
             app:layout_constraintTop_toBottomOf="@+id/exp_numTrials" />
 
         <TextView
-            android:id="@+id/exp_status_title"
+            android:id="@+id/exp_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="36dp"
+            android:text="active"
+            android:textColor="#131313"
+            app:layout_constraintStart_toEndOf="@+id/exp_ownerName_title"
+            app:layout_constraintTop_toBottomOf="@+id/exp_numTrials" />
+
+        <TextView
+            android:id="@+id/exp_published_title"
             android:layout_width="0dp"
             android:layout_height="19dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
-            android:text="@string/status"
+            android:text="@string/published"
             android:textColor="#0E0E0E"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/exp_title" />
 
         <TextView
-            android:id="@+id/exp_status"
+            android:id="@+id/exp_published"
             android:layout_width="0dp"
             android:layout_height="19dp"
             android:layout_marginTop="8dp"
-            android:text="Status"
+            android:text="unpublished"
             android:textColor="#0E0E0E"
-            app:layout_constraintStart_toEndOf="@+id/exp_status_title"
+            app:layout_constraintStart_toEndOf="@+id/exp_published_title"
             app:layout_constraintTop_toBottomOf="@+id/exp_description" />
 
         <TextView
@@ -113,7 +133,7 @@
             android:text="@string/region"
             android:textColor="#090909"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/exp_status_title" />
+            app:layout_constraintTop_toBottomOf="@+id/exp_published_title" />
 
         <TextView
             android:id="@+id/exp_region"
@@ -123,7 +143,7 @@
             android:text="Region"
             android:textColor="#090909"
             app:layout_constraintStart_toEndOf="@+id/exp_region_Title"
-            app:layout_constraintTop_toBottomOf="@+id/exp_status" />
+            app:layout_constraintTop_toBottomOf="@+id/exp_published" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="date"><b>Date: </b></string>
     <string name="asker"><b>Asker: </b></string>
     <string name="question"><b>Q: </b></string>
+    <string name="published"><b>Published: </b></string>
     <string name="comment"><b>C: </b></string>
     <string name="replies"><b>Replies: </b></string>
     <string name="description"><b>Description: </b></string>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] JavaDocs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Code has been properly commented
- [x] Camel case has been used




## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Adding a proper publish button, and a proper end button to end and publish experiments, ending an experiment does not allow anyone to add or delete anything as well as displays the experiment in the adapter as inactive. Publishing only shows the experiment in the adapter as published. 
Issue Number: US 01.02.01, US 01.03.01


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Experiment Adapter now shows Experiment Status and whether an experiment is published
- There are now two buttons in the trial log for end and publish
- Inactive appears red, published appears blue

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
![image](https://user-images.githubusercontent.com/55824865/114126450-4dfb2180-98ad-11eb-9789-177defd64b34.png)
![image](https://user-images.githubusercontent.com/55824865/114126486-5eab9780-98ad-11eb-8132-e44d6e17ff08.png)
